### PR TITLE
Update swipebox.gemspec to allow rails 4.2

### DIFF
--- a/swipebox.gemspec
+++ b/swipebox.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'rails', '>= 3.1', '< 5.0'
-  s.add_dependency 'sass-rails', '>= 3.1', '< 5.0'
+  s.add_dependency 'sass-rails', '>= 3.1', '< 6.0'
 
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'capybara', '~> 2'


### PR DESCRIPTION
`sass-rails` is a version number ahead of `rails`